### PR TITLE
Add test to GET/api to check for comparison of api file to original

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -3,6 +3,7 @@ const request = require('supertest');
 const db = require('../db/connection');
 const seed = require('../db/seeds/seed');
 const data = require('../db/data/test-data');
+const fs = require('fs');
 
 beforeEach(() => seed(data));
 afterAll(() => db.end());
@@ -32,6 +33,18 @@ describe('GET/api', () => {
         for (let endpoint in endpointDetails) {
           expect(typeof endpointDetails[endpoint].description).toBe('string');
         }
+      });
+  });
+  test('GET:200 compares original json file to be equal to the data sent back from api', () => {
+    const originalEndpointDetails = fs.readFileSync(
+      './endpoints.json',
+      'utf-8'
+    );
+    return request(app)
+      .get('/api')
+      .expect(200)
+      .then((res) => {
+        expect(res.body.details).toEqual(JSON.parse(originalEndpointDetails));
       });
   });
 });

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -15,7 +15,7 @@ exports.selectTopics = () => {
 };
 
 exports.selectApiDetails = () => {
-  return fs.readFile(`endpoints.json`, 'utf-8').then((details) => {
+  return fs.readFile('endpoints.json', 'utf-8').then((details) => {
     return JSON.parse(details);
   });
 };


### PR DESCRIPTION
This is an updated PR for task 3 with added test to check for comparison between the original endpoints file with what gets returned from api.